### PR TITLE
Update dev command in Vue README

### DIFF
--- a/OpenMonitor/vue_frontend/README.md
+++ b/OpenMonitor/vue_frontend/README.md
@@ -7,8 +7,9 @@ npm install
 
 ### Compiles and hot-reloads for development
 ```
-npm run serve
+npm run dev
 ```
+Use `npm run serve` to preview the production build.
 
 ### Compiles and minifies for production
 ```


### PR DESCRIPTION
## Summary
- update instructions to use `npm run dev` in `vue_frontend/README.md`
- clarify that `npm run serve` is for previewing the build

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f026459d48320b7875137b9cd7415