### PR TITLE
Fix Docker setup with Vuetify and PostgreSQL

### DIFF
--- a/OpenMonitor/django_app/openmonitor_backend/settings.py
+++ b/OpenMonitor/django_app/openmonitor_backend/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -75,8 +76,12 @@ WSGI_APPLICATION = 'openmonitor_backend.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('POSTGRES_DB', 'openmonitor'),
+        'USER': os.environ.get('POSTGRES_USER', 'admin'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'password'),
+        'HOST': os.environ.get('POSTGRES_HOST', 'postgres_django'),
+        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
     }
 }
 

--- a/OpenMonitor/nginx/nginx.conf
+++ b/OpenMonitor/nginx/nginx.conf
@@ -9,7 +9,7 @@ http {
         server_name localhost;
 
         location /openmonitor/ {
-            proxy_pass http://vue:5174;
+            proxy_pass http://vue:5174/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -18,7 +18,7 @@ http {
 
 
         location /openmonitor-api/ {
-            proxy_pass http://django:8000;
+            proxy_pass http://django:8000/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/OpenMonitor/vue_frontend/package.json
+++ b/OpenMonitor/vue_frontend/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^1.0.0",
-    "vite": "^5.4.9"
+    "vite": "^5.4.9",
+    "vite-plugin-vuetify": "^1.0.2"
   }
 }

--- a/OpenMonitor/vue_frontend/src/main.js
+++ b/OpenMonitor/vue_frontend/src/main.js
@@ -1,8 +1,7 @@
-import { createApp } from 'vue'; // Importa createApp desde vue
-import App from './App.vue';
-import vuetify from './plugins/vuetify'; // Importa vuetify
+import { createApp } from 'vue'
+import App from './App.vue'
+import vuetify from './plugins/vuetify'
 
-
-const app = createApp(App); // Crea la aplicación
-app.use(vuetify); // Usa vuetify
-app.mount('#app'); // Móntala en el DOM
+const app = createApp(App)
+app.use(vuetify)
+app.mount('#app')

--- a/OpenMonitor/vue_frontend/src/plugins/vuetify.js
+++ b/OpenMonitor/vue_frontend/src/plugins/vuetify.js
@@ -1,0 +1,9 @@
+import 'vuetify/styles'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+export default createVuetify({
+  components,
+  directives
+})

--- a/OpenMonitor/vue_frontend/vite.config.js
+++ b/OpenMonitor/vue_frontend/vite.config.js
@@ -1,12 +1,13 @@
-import { defineConfig } from 'vite';
-import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import vuetify from 'vite-plugin-vuetify'
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), vuetify()],
   base: '/openmonitor/',
   server: {
     host: '0.0.0.0',
-    port: 5174,  // Cambia aquí el puerto
-    strictPort: true,  // Para asegurar que no use otro puerto si este está ocupado
+    port: 5174,
+    strictPort: true
   }
-});
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,17 @@ services:
       - openmonitor_network
 
   django:
-    env_file:
-      - .env
     build:
-      context: ./OpenMonitor/django_app  # Refleja la estructura correcta
-      dockerfile: Dockerfile  # Asegúrate de que el Dockerfile esté correctamente nombrado y en esta carpeta
+      context: ./OpenMonitor/django_app
+      dockerfile: Dockerfile
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - ./OpenMonitor/django_app:/app  # Asegúrate de mapear correctamente la carpeta django_app
+      - ./OpenMonitor/django_app:/app
+    environment:
+      POSTGRES_DB: openmonitor
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOST: postgres_django
     ports:
       - "8000:8000"
     depends_on:
@@ -32,8 +35,8 @@ services:
       context: ./OpenMonitor/vue_frontend
       dockerfile: Dockerfile
     volumes:
-    - ./OpenMonitor/vue_frontend/src:/app/src
-    - ./OpenMonitor/vue_frontend/package.json:/app/package.json
+      - ./OpenMonitor/vue_frontend/src:/app/src
+      - ./OpenMonitor/vue_frontend/package.json:/app/package.json
     ports:
       - "5174:5174"
     networks:


### PR DESCRIPTION
## Summary
- configure docker-compose services and postgres env vars
- enable Vuetify 3 using vite-plugin-vuetify
- add Vuetify plugin file and update main.js
- update vite config for plugin
- add nginx proxy pass trailing slashes
- switch Django settings to PostgreSQL

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f0b5e76848320a0d905478ac21dce